### PR TITLE
add option to read initial response in network connection check

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -32,6 +32,11 @@ pub(crate) struct Options {
     // check options for plain sockets
     #[arg(long = "socket-addr", env = "EASYCHECK_SOCKET_ADDR")]
     pub socket_check_addr: Option<SocketAddr>,
+    #[arg(
+        long = "read-initial-response",
+        env = "EASYCHECK_READ_INITIAL_RESPONSE"
+    )]
+    pub socket_check_read_initial_response: Option<bool>,
     // check options for http checks
     #[arg(long = "http-url", env = "EASYCHECK_HTTP_URL")]
     pub http_check_url: Option<Uri>,


### PR DESCRIPTION
Designed for waiting for the initial greeting of postfix.

As of postfix version 3.8.6 postfix logged a message like
```
2025-04-14T13:11:38.878267+00:00 alexander-test-mail13 postfix/smtpd[11111]: connect from localhost.localdomain[127.0.0.1]
2025-04-14T13:11:38.878907+00:00 alexander-test-mail13 postfix/smtpd[11111]: improper command pipelining after CONNECT from localhost.localdomain[127.0.0.1]: QUIT\n
2025-04-14T13:11:38.879324+00:00 alexander-test-mail13 postfix/smtpd[11111]: disconnect from localhost.localdomain[127.0.0.1] quit=1 commands=1
```
when requested by the easycheck network checker.  This was because we send the QUIT signal before Postifx answered with its greeting message, as described in https://github.com/vdukhovni/postfix/blame/513334ef532aa27ee85aa7b0ef98fbee30b7eeae/postfix/src/smtpd/smtpd.c#L5714
and https://github.com/vdukhovni/postfix/blame/513334ef532aa27ee85aa7b0ef98fbee30b7eeae/postfix/src/smtpd/smtpd.c#L5548C12-L5548C37

With the new flag we wait for the initial greeting from postfix as `220 mail13.easybill.io ESMTP Postfix (Ubuntu)` in 
```
alexander@alexander-test-mail13:~$ telnet 127.0.0.1 25
Trying 127.0.0.1...
Connected to 127.0.0.1.
Escape character is '^]'.
220 mail13.easybill.io ESMTP Postfix (Ubuntu)
HELO myhost
250 mail13.easybill.io
QUIT
221 2.0.0 Bye
Connection closed by foreign host.
```
