### PR TITLE
feat: use Cargo.toml as version source, add tests and structured logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,26 @@ jobs:
       - name: Run clippy
         uses: clechasseur/rs-clippy-check@v5
 
+  test:
+    needs: [ "check" ]
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Initialize Rust caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --all-targets
+
   build:
+    needs: [ "test" ]
     permissions: read-all
     runs-on: ${{ matrix.platform.os }}
     name: Compile ${{ matrix.platform.target }} / ${{ matrix.platform.os }}
@@ -89,7 +108,7 @@ jobs:
           name: easycheck_${{ matrix.platform.osn }}_${{ matrix.platform.arch }}
 
   release:
-    needs: [ "check", "build" ]
+    needs: [ "check", "test", "build" ]
     name: Publish Release
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release == 'true' }}
@@ -99,11 +118,20 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Build tag name
-        env:
-          RUN: ${{ github.run_number }}
-          ATTEMPT: ${{ github.run_attempt }}
-        run: echo "TAG_NAME=1.$RUN.$(($ATTEMPT - 1))" >> $GITHUB_ENV;
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check version was bumped
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          if [ "$VERSION" = "$LATEST_TAG" ]; then
+            echo "::error::Cargo.toml version ($VERSION) matches latest tag. Bump the version before releasing."
+            exit 1
+          fi
+          echo "TAG_NAME=$VERSION" >> $GITHUB_ENV
 
       - name: Download artifacts
         uses: actions/download-artifact@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,10 +137,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -149,10 +161,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -201,6 +229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "easycheck"
 version = "1.35.0"
 dependencies = [
@@ -215,12 +254,12 @@ dependencies = [
  "hyper-util",
  "log",
  "proxy-header",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "tokio-test",
- "tower",
 ]
 
 [[package]]
@@ -267,6 +306,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -374,6 +419,33 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -474,19 +546,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -494,6 +672,27 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -505,6 +704,22 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -544,6 +759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36139f1c97c42c0c86a411910b04e48d4939a0376e6e0f989420cbdee0120e5"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +787,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +806,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchit"
@@ -674,6 +911,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +958,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +1026,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -756,6 +1095,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +1164,47 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -853,6 +1291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,10 +1329,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -906,6 +1362,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -914,11 +1384,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -946,6 +1461,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -984,6 +1509,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1037,6 +1580,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,6 +1643,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff9c7baef35ac3c0e17d8bfc9ad75eb62f85a2f02bccc906699dadb0aa9c622"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24699cd39db9966cf6e2ef10d2f72779c961ad905911f395ea201c3ec9f545d"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39455e84ad887a0bbc93c116d72403f1bb0a39e37dd6f235a43e2128a0c7f1fd"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff4761f60b0b51fd13fec8764167b7bbcc34498ce3e52805fe1db6f2d56b6d6"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6a171c53d98021a93a474c4a4579d76ba97f9517d871bc12e27640f218b6dd"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1736,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668fa5d00434e890a452ab060d24e3904d1be93f7bb01b70e5603baa2b8ab23b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,11 +1772,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1135,20 +1799,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1158,9 +1844,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1170,9 +1868,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1182,15 +1892,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1284,6 +2012,115 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,9 +166,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bumpalo"
@@ -167,8 +189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -223,10 +253,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -238,6 +303,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "easycheck"
@@ -327,6 +398,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -559,7 +636,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -759,6 +835,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +961,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking_lot"
@@ -971,7 +1085,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -983,6 +1097,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -992,7 +1107,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1009,7 +1124,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1096,9 +1211,9 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -1116,9 +1231,9 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1129,7 +1244,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1171,12 +1285,24 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1190,11 +1316,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1213,10 +1367,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1392,11 +1587,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1610,6 +1825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,12 +1981,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.2"
+name = "webpki-root-certs"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1769,6 +2003,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1795,6 +2038,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1832,6 +2090,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1844,6 +2108,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1853,6 +2123,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1880,6 +2156,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1889,6 +2171,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1904,6 +2192,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1913,6 +2207,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,20 +202,54 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "easycheck"
-version = "0.1.0"
+version = "1.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "clap",
+ "env_logger",
  "futures",
  "http-body-util",
  "hyper",
  "hyper-util",
+ "log",
  "proxy-header",
  "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
+ "tower",
 ]
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -217,6 +260,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -317,6 +372,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +489,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,10 +519,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jiff"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -521,6 +658,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,12 +711,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -568,6 +778,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -691,6 +907,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +1008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +1033,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -887,6 +1174,94 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-test",
  "tower",
 ]
 
@@ -945,6 +946,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
+dependencies = [
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ env_logger = "0.11"
 [dev-dependencies]
 tempfile = "3"
 serde_json = "1.0"
-tower = { version = "0.5", features = ["util"] }
 tokio-test = "0.4"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+hyper = { version = "1.8.*", features = ["server"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,23 +7,23 @@ edition = "2021"
 rust-version = "1.79"
 
 [dependencies]
-anyhow = "*"
-axum = "0.8.*"
-futures = "0.3.*"
-async-trait = "0.1.*"
-http-body-util = "0.1.*"
-tokio = { version = "1.49.*", features = ["full"] }
-hyper-util = { version = "0.1.*", features = ["tokio"] }
-proxy-header = { version = "0.1.*", features = ["tokio"] }
-hyper = { version = "1.8.*", features = ["client", "http1"] }
-serde = { version = "1.0.*", features = ["derive"] }
-clap = { version = "4.5.*", features = ["derive", "env"] }
+anyhow = "1"
+axum = "0.8"
+futures = "0.3"
+async-trait = "0.1"
+http-body-util = "0.1"
+tokio = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+proxy-header = { version = "0.1", features = ["tokio"] }
+hyper = { version = "1", features = ["client", "http1"] }
+serde = { version = "1", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 log = "0.4"
 env_logger = "0.11"
 
 [dev-dependencies]
 tempfile = "3"
-serde_json = "1.0"
+serde_json = "1"
 tokio-test = "0.4"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-hyper = { version = "1.8.*", features = ["server"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+hyper = { version = "1.8", features = ["server"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ env_logger = "0.11"
 tempfile = "3"
 serde_json = "1.0"
 tower = { version = "0.5", features = ["util"] }
+tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easycheck"
-version = "0.1.0"
+version = "1.35.0"
 authors = ["Pasqual Koschmieder"]
 
 edition = "2021"
@@ -18,3 +18,10 @@ proxy-header = { version = "0.1.*", features = ["tokio"] }
 hyper = { version = "1.8.*", features = ["client", "http1"] }
 serde = { version = "1.0.*", features = ["derive"] }
 clap = { version = "4.5.*", features = ["derive", "env"] }
+log = "0.4"
+env_logger = "0.11"
+
+[dev-dependencies]
+tempfile = "3"
+serde_json = "1.0"
+tower = { version = "0.5", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ tempfile = "3"
 serde_json = "1"
 tokio-test = "0.4"
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
-hyper = { version = "1.8", features = ["server"] }
+hyper = { version = "1", features = ["server"] }

--- a/src/checks/force_success_file_check.rs
+++ b/src/checks/force_success_file_check.rs
@@ -66,12 +66,4 @@ mod tests {
         assert!(result.failure_reason.is_none());
         assert!(!result.ignore_other_results);
     }
-
-    #[test]
-    fn check_name_returns_force_success_file() {
-        let check = ForceSuccessFileCheck {
-            file_path: PathBuf::from("/tmp/test"),
-        };
-        assert_eq!(check.check_name(), "force success file");
-    }
 }

--- a/src/checks/force_success_file_check.rs
+++ b/src/checks/force_success_file_check.rs
@@ -27,6 +27,7 @@ impl StatusChecker for ForceSuccessFileCheck {
     }
 
     async fn execute_check(&self) -> anyhow::Result<StatusCheckResult> {
+        log::debug!("checking force success file at {:?}", &self.file_path);
         match fs::metadata(&self.file_path).await {
             Ok(_) => {
                 let check_result = StatusCheckResult::new_success().ignore_other_results();
@@ -37,5 +38,40 @@ impl StatusChecker for ForceSuccessFileCheck {
                 Ok(check_result)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn file_present_returns_success_with_ignore() {
+        let tmp = NamedTempFile::new().unwrap();
+        let check = ForceSuccessFileCheck {
+            file_path: tmp.path().to_path_buf(),
+        };
+        let result = check.execute_check().await.unwrap();
+        assert!(result.failure_reason.is_none());
+        assert!(result.ignore_other_results);
+    }
+
+    #[tokio::test]
+    async fn file_absent_returns_success_without_ignore() {
+        let check = ForceSuccessFileCheck {
+            file_path: PathBuf::from("/tmp/easycheck_nonexistent_force_success_test"),
+        };
+        let result = check.execute_check().await.unwrap();
+        assert!(result.failure_reason.is_none());
+        assert!(!result.ignore_other_results);
+    }
+
+    #[test]
+    fn check_name_returns_force_success_file() {
+        let check = ForceSuccessFileCheck {
+            file_path: PathBuf::from("/tmp/test"),
+        };
+        assert_eq!(check.check_name(), "force success file");
     }
 }

--- a/src/checks/http_response_check.rs
+++ b/src/checks/http_response_check.rs
@@ -1,5 +1,6 @@
 use crate::options::{Options, ProxyProtocolVersion};
 use crate::status::status_checker::{StatusCheckResult, StatusChecker};
+use crate::util::tcp_connector::{RealTcpConnector, TcpConnector};
 use anyhow::Context;
 use async_trait::async_trait;
 use http_body_util::Empty;
@@ -13,10 +14,8 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use tokio::net::TcpStream;
 use tokio::time::timeout;
 
-#[derive(Debug)]
 pub(crate) struct HttpResponseCheck {
     remote_addr: SocketAddr,
     host_header_value: String,
@@ -25,6 +24,7 @@ pub(crate) struct HttpResponseCheck {
     http_method: Method,
     up_status_codes: Vec<StatusCode>,
     proxy_protocol_version: Option<ProxyProtocolVersion>,
+    connector: Box<dyn TcpConnector>,
 }
 
 fn encode_proxy_header(version: &ProxyProtocolVersion) -> anyhow::Result<Vec<u8>> {
@@ -85,6 +85,7 @@ impl StatusChecker for HttpResponseCheck {
                     http_method,
                     up_status_codes,
                     proxy_protocol_version,
+                    connector: Box::new(RealTcpConnector),
                 }))
             }
         }
@@ -102,14 +103,13 @@ impl StatusChecker for HttpResponseCheck {
             &self.request_line_target
         );
         let response_code = timeout(Duration::from_secs(5), async {
-            let mut remote_stream = TcpStream::connect(&self.remote_addr).await?;
+            let mut remote_stream = self.connector.connect(&self.remote_addr).await?;
             if let Some(proxy_protocol_version) = &self.proxy_protocol_version {
                 let proxy_protocol_data = encode_proxy_header(proxy_protocol_version)?;
                 remote_stream.write_all(&proxy_protocol_data).await?;
             }
 
-            let (mut sender, connection) =
-                handshake::<TokioIo<TcpStream>, Empty<Bytes>>(TokioIo::new(remote_stream)).await?;
+            let (mut sender, connection) = handshake(TokioIo::new(remote_stream)).await?;
             tokio::spawn(connection);
 
             let request = Request::builder()
@@ -122,78 +122,264 @@ impl StatusChecker for HttpResponseCheck {
         })
         .await??;
 
-        let check_result = if self.up_status_codes.contains(&response_code) {
+        Ok(self.evaluate_response_code(response_code))
+    }
+}
+
+impl HttpResponseCheck {
+    fn evaluate_response_code(&self, response_code: StatusCode) -> StatusCheckResult {
+        if self.up_status_codes.contains(&response_code) {
             StatusCheckResult::new_success()
         } else {
             StatusCheckResult::new_failure(format!("received status {}", &response_code))
-        };
-        Ok(check_result)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::routing::get;
-    use axum::Router;
-    use tokio::net::TcpListener;
+    use crate::util::tcp_connector::AsyncStream;
+    use std::io;
+    use std::pin::Pin;
 
-    async fn start_test_server(status: StatusCode) -> SocketAddr {
-        let app = Router::new().route("/health", get(move || async move { (status, "ok") }));
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
-        addr
+    struct MockConnector {
+        stream: std::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
     }
 
-    fn make_check(addr: SocketAddr) -> HttpResponseCheck {
-        let endpoint: Uri = format!("http://{}/health", addr).parse().unwrap();
-        HttpResponseCheck {
-            remote_addr: addr,
-            host_header_value: addr.to_string(),
-            endpoint,
-            request_line_target: "/health".to_string(),
-            http_method: Method::GET,
-            up_status_codes: vec![StatusCode::OK],
-            proxy_protocol_version: None,
+    impl MockConnector {
+        fn new(stream: impl AsyncStream + 'static) -> Self {
+            Self {
+                stream: std::sync::Mutex::new(Some(Box::pin(stream))),
+            }
         }
     }
 
+    struct FailingConnector {
+        error_kind: io::ErrorKind,
+    }
+
+    #[async_trait]
+    impl TcpConnector for MockConnector {
+        async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
+            self.stream
+                .lock()
+                .unwrap()
+                .take()
+                .ok_or_else(|| io::Error::other("stream already consumed"))
+        }
+    }
+
+    #[async_trait]
+    impl TcpConnector for FailingConnector {
+        async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
+            Err(io::Error::new(self.error_kind, "connection refused"))
+        }
+    }
+
+    fn dummy_addr() -> SocketAddr {
+        "127.0.0.1:9999".parse().unwrap()
+    }
+
+    fn make_check(up_status_codes: Vec<StatusCode>) -> HttpResponseCheck {
+        HttpResponseCheck {
+            remote_addr: dummy_addr(),
+            host_header_value: dummy_addr().to_string(),
+            endpoint: format!("http://{}/health", dummy_addr()).parse().unwrap(),
+            request_line_target: "/health".to_string(),
+            http_method: Method::GET,
+            up_status_codes,
+            proxy_protocol_version: None,
+            connector: Box::new(RealTcpConnector),
+        }
+    }
+
+    fn make_check_with_connector(
+        up_status_codes: Vec<StatusCode>,
+        proxy_protocol_version: Option<ProxyProtocolVersion>,
+        connector: Box<dyn TcpConnector>,
+    ) -> HttpResponseCheck {
+        HttpResponseCheck {
+            remote_addr: dummy_addr(),
+            host_header_value: dummy_addr().to_string(),
+            endpoint: format!("http://{}/health", dummy_addr()).parse().unwrap(),
+            request_line_target: "/health".to_string(),
+            http_method: Method::GET,
+            up_status_codes,
+            proxy_protocol_version,
+            connector,
+        }
+    }
+
+    /// Spawns a minimal HTTP/1 server on the given stream that returns the
+    /// specified status code for any request it receives.
+    async fn spawn_http_server(server_stream: tokio::io::DuplexStream, status: StatusCode) {
+        use http_body_util::Full;
+        use hyper::server::conn::http1::Builder;
+        use hyper::service::service_fn;
+        use hyper::{body::Bytes as HyperBytes, Response};
+
+        let service = service_fn(move |_req: Request<hyper::body::Incoming>| async move {
+            Ok::<_, hyper::Error>(
+                Response::builder()
+                    .status(status)
+                    .body(Full::new(HyperBytes::from("ok")))
+                    .unwrap(),
+            )
+        });
+
+        let _ = Builder::new()
+            .serve_connection(TokioIo::new(server_stream), service)
+            .await;
+    }
+
+    /// Reads a proxy protocol header of known length from the server stream,
+    /// then serves HTTP using hyper. Returns the captured prefix bytes.
+    async fn spawn_proxy_protocol_http_server(
+        mut server_stream: tokio::io::DuplexStream,
+        status: StatusCode,
+        prefix_len: usize,
+    ) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+
+        let mut prefix = vec![0u8; prefix_len];
+        server_stream.read_exact(&mut prefix).await.unwrap();
+
+        spawn_http_server(server_stream, status).await;
+        prefix
+    }
+
+    #[test]
+    fn matching_status_code_returns_success() {
+        let check = make_check(vec![StatusCode::OK]);
+        let result = check.evaluate_response_code(StatusCode::OK);
+        assert!(result.failure_reason.is_none());
+    }
+
+    #[test]
+    fn non_matching_status_code_returns_failure() {
+        let check = make_check(vec![StatusCode::OK]);
+        let result = check.evaluate_response_code(StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(result.failure_reason.is_some());
+        assert!(result.failure_reason.unwrap().contains("500"));
+    }
+
+    #[test]
+    fn multiple_accepted_codes() {
+        let check = make_check(vec![StatusCode::OK, StatusCode::NO_CONTENT]);
+        assert!(check
+            .evaluate_response_code(StatusCode::OK)
+            .failure_reason
+            .is_none());
+        assert!(check
+            .evaluate_response_code(StatusCode::NO_CONTENT)
+            .failure_reason
+            .is_none());
+        assert!(check
+            .evaluate_response_code(StatusCode::NOT_FOUND)
+            .failure_reason
+            .is_some());
+    }
+
+    #[test]
+    fn check_name_contains_endpoint() {
+        let check = make_check(vec![StatusCode::OK]);
+        let name = check.check_name();
+        assert!(name.contains("127.0.0.1:9999"));
+    }
+
     #[tokio::test]
-    async fn returns_success_for_200() {
-        let addr = start_test_server(StatusCode::OK).await;
-        let check = make_check(addr);
+    async fn http_request_succeeds() {
+        let (client_stream, server_stream) = tokio::io::duplex(8192);
+
+        tokio::spawn(spawn_http_server(server_stream, StatusCode::OK));
+
+        let check = make_check_with_connector(
+            vec![StatusCode::OK],
+            None,
+            Box::new(MockConnector::new(client_stream)),
+        );
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_none());
     }
 
     #[tokio::test]
-    async fn returns_failure_for_500() {
-        let addr = start_test_server(StatusCode::INTERNAL_SERVER_ERROR).await;
-        let check = make_check(addr);
+    async fn http_request_non_matching_status_returns_failure() {
+        let (client_stream, server_stream) = tokio::io::duplex(8192);
+
+        tokio::spawn(spawn_http_server(
+            server_stream,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ));
+
+        let check = make_check_with_connector(
+            vec![StatusCode::OK],
+            None,
+            Box::new(MockConnector::new(client_stream)),
+        );
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_some());
         assert!(result.failure_reason.unwrap().contains("500"));
     }
 
     #[tokio::test]
-    async fn connection_refused_returns_error() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
+    async fn http_request_with_proxy_protocol_v1() {
+        let expected_header = encode_proxy_header(&ProxyProtocolVersion::V1).unwrap();
+        let prefix_len = expected_header.len();
 
-        let check = make_check(addr);
-        let result = check.execute_check().await;
-        assert!(result.is_err());
+        let (client_stream, server_stream) = tokio::io::duplex(8192);
+        let server_handle = tokio::spawn(spawn_proxy_protocol_http_server(
+            server_stream,
+            StatusCode::OK,
+            prefix_len,
+        ));
+
+        let check = make_check_with_connector(
+            vec![StatusCode::OK],
+            Some(ProxyProtocolVersion::V1),
+            Box::new(MockConnector::new(client_stream)),
+        );
+        let result = check.execute_check().await.unwrap();
+        assert!(result.failure_reason.is_none());
+
+        let prefix = server_handle.await.unwrap();
+        assert_eq!(prefix, expected_header);
     }
 
-    #[test]
-    fn check_name_contains_endpoint() {
-        let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
-        let check = make_check(addr);
-        let name = check.check_name();
-        assert!(name.contains("127.0.0.1:9999"));
+    #[tokio::test]
+    async fn http_request_with_proxy_protocol_v2() {
+        let expected_header = encode_proxy_header(&ProxyProtocolVersion::V2).unwrap();
+        let prefix_len = expected_header.len();
+
+        let (client_stream, server_stream) = tokio::io::duplex(8192);
+        let server_handle = tokio::spawn(spawn_proxy_protocol_http_server(
+            server_stream,
+            StatusCode::OK,
+            prefix_len,
+        ));
+
+        let check = make_check_with_connector(
+            vec![StatusCode::OK],
+            Some(ProxyProtocolVersion::V2),
+            Box::new(MockConnector::new(client_stream)),
+        );
+        let result = check.execute_check().await.unwrap();
+        assert!(result.failure_reason.is_none());
+
+        let prefix = server_handle.await.unwrap();
+        assert_eq!(prefix, expected_header);
+    }
+
+    #[tokio::test]
+    async fn connection_failure_returns_error() {
+        let check = make_check_with_connector(
+            vec![StatusCode::OK],
+            None,
+            Box::new(FailingConnector {
+                error_kind: io::ErrorKind::ConnectionRefused,
+            }),
+        );
+        let result = check.execute_check().await;
+        assert!(result.is_err());
     }
 }

--- a/src/checks/http_response_check.rs
+++ b/src/checks/http_response_check.rs
@@ -144,13 +144,13 @@ mod tests {
     use std::pin::Pin;
 
     struct MockConnector {
-        stream: std::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
+        stream: tokio::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
     }
 
     impl MockConnector {
         fn new(stream: impl AsyncStream + 'static) -> Self {
             Self {
-                stream: std::sync::Mutex::new(Some(Box::pin(stream))),
+                stream: tokio::sync::Mutex::new(Some(Box::pin(stream))),
             }
         }
     }
@@ -164,7 +164,7 @@ mod tests {
         async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
             self.stream
                 .lock()
-                .unwrap()
+                .await
                 .take()
                 .ok_or_else(|| io::Error::other("stream already consumed"))
         }

--- a/src/checks/mtc_file_check.rs
+++ b/src/checks/mtc_file_check.rs
@@ -73,12 +73,4 @@ mod tests {
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_none());
     }
-
-    #[test]
-    fn check_name_returns_mtc_file() {
-        let check = MtcFileCheck {
-            file_path: PathBuf::from("/tmp/test"),
-        };
-        assert_eq!(check.check_name(), "mtc file");
-    }
 }

--- a/src/checks/mtc_file_check.rs
+++ b/src/checks/mtc_file_check.rs
@@ -28,6 +28,7 @@ impl StatusChecker for MtcFileCheck {
     }
 
     async fn execute_check(&self) -> anyhow::Result<StatusCheckResult> {
+        log::debug!("checking mtc file at {:?}", &self.file_path);
         match fs::metadata(&self.file_path).await {
             Ok(_) => {
                 let reason = String::from("mtc file exists");
@@ -46,5 +47,38 @@ impl StatusChecker for MtcFileCheck {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn file_present_returns_failure() {
+        let tmp = NamedTempFile::new().unwrap();
+        let check = MtcFileCheck {
+            file_path: tmp.path().to_path_buf(),
+        };
+        let result = check.execute_check().await.unwrap();
+        assert_eq!(result.failure_reason.as_deref(), Some("mtc file exists"));
+    }
+
+    #[tokio::test]
+    async fn file_absent_returns_success() {
+        let check = MtcFileCheck {
+            file_path: PathBuf::from("/tmp/easycheck_nonexistent_mtc_file_test"),
+        };
+        let result = check.execute_check().await.unwrap();
+        assert!(result.failure_reason.is_none());
+    }
+
+    #[test]
+    fn check_name_returns_mtc_file() {
+        let check = MtcFileCheck {
+            file_path: PathBuf::from("/tmp/test"),
+        };
+        assert_eq!(check.check_name(), "mtc file");
     }
 }

--- a/src/checks/network_connection_check.rs
+++ b/src/checks/network_connection_check.rs
@@ -107,13 +107,13 @@ mod tests {
     use std::pin::Pin;
 
     struct MockConnector {
-        stream: std::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
+        stream: tokio::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
     }
 
     impl MockConnector {
         fn new(stream: impl AsyncStream + 'static) -> Self {
             Self {
-                stream: std::sync::Mutex::new(Some(Box::pin(stream))),
+                stream: tokio::sync::Mutex::new(Some(Box::pin(stream))),
             }
         }
     }
@@ -127,7 +127,7 @@ mod tests {
         async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
             self.stream
                 .lock()
-                .unwrap()
+                .await
                 .take()
                 .ok_or_else(|| io::Error::other("stream already consumed"))
         }

--- a/src/checks/network_connection_check.rs
+++ b/src/checks/network_connection_check.rs
@@ -2,16 +2,17 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tokio::time::timeout;
 
 use crate::options::Options;
 use crate::status::status_checker::{StatusCheckResult, StatusChecker};
+use crate::util::tcp_connector::{RealTcpConnector, TcpConnector};
 
 pub(crate) struct NetworkConnectionCheck {
     target_address: SocketAddr,
     read_initial_response: bool,
+    connector: Box<dyn TcpConnector>,
 }
 
 #[async_trait]
@@ -25,6 +26,7 @@ impl StatusChecker for NetworkConnectionCheck {
                 Ok(Some(Self {
                     target_address,
                     read_initial_response,
+                    connector: Box::new(RealTcpConnector),
                 }))
             }
         }
@@ -42,7 +44,7 @@ impl StatusChecker for NetworkConnectionCheck {
         );
         match timeout(
             Duration::from_secs(5),
-            TcpStream::connect(&self.target_address),
+            self.connector.connect(&self.target_address),
         )
         .await
         {
@@ -59,17 +61,16 @@ impl StatusChecker for NetworkConnectionCheck {
                             format!("error connecting to {}: {}", self.target_address, err);
                         Ok(StatusCheckResult::new_failure(failure_reason))
                     }
-                    Ok(mut tcp_stream) => {
+                    Ok(mut stream) => {
                         if self.read_initial_response {
-                            if let Some(result) =
-                                self.read_and_discard_response(&mut tcp_stream).await
+                            if let Some(result) = Self::read_and_discard_response(&mut stream).await
                             {
                                 return Ok(result);
                             }
                         }
 
                         // connection successful
-                        if let Err(err) = tcp_stream.write_all(b"QUIT\n").await {
+                        if let Err(err) = stream.write_all(b"QUIT\n").await {
                             let failure_reason = format!(
                                 "error sending QUIT message to {}: {}",
                                 self.target_address, err
@@ -78,8 +79,7 @@ impl StatusChecker for NetworkConnectionCheck {
                         }
 
                         // receive & discard response from server
-                        if let Some(result) = self.read_and_discard_response(&mut tcp_stream).await
-                        {
+                        if let Some(result) = Self::read_and_discard_response(&mut stream).await {
                             return Ok(result);
                         }
 
@@ -94,11 +94,10 @@ impl StatusChecker for NetworkConnectionCheck {
 
 impl NetworkConnectionCheck {
     async fn read_and_discard_response(
-        &self,
-        tcp_stream: &mut TcpStream,
+        stream: &mut (dyn AsyncRead + Unpin + Send),
     ) -> Option<StatusCheckResult> {
         let mut buffer = [0; 1024];
-        if let Err(err) = tcp_stream.read(&mut buffer).await {
+        if let Err(err) = stream.read(&mut buffer).await {
             let failure_reason = format!("error receiving response: {}", err);
             return Some(StatusCheckResult::new_failure(failure_reason));
         }
@@ -109,32 +108,60 @@ impl NetworkConnectionCheck {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::util::tcp_connector::AsyncStream;
+    use std::io;
     use std::net::SocketAddr;
-    use tokio::io::AsyncWriteExt;
-    use tokio::net::TcpListener;
+    use std::pin::Pin;
+
+    struct MockConnector {
+        stream: std::sync::Mutex<Option<Pin<Box<dyn AsyncStream>>>>,
+    }
+
+    impl MockConnector {
+        fn new(stream: impl AsyncStream + 'static) -> Self {
+            Self {
+                stream: std::sync::Mutex::new(Some(Box::pin(stream))),
+            }
+        }
+    }
+
+    struct FailingConnector {
+        error_kind: io::ErrorKind,
+    }
+
+    #[async_trait]
+    impl TcpConnector for MockConnector {
+        async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
+            self.stream
+                .lock()
+                .unwrap()
+                .take()
+                .ok_or_else(|| io::Error::other("stream already consumed"))
+        }
+    }
+
+    #[async_trait]
+    impl TcpConnector for FailingConnector {
+        async fn connect(&self, _addr: &SocketAddr) -> io::Result<Pin<Box<dyn AsyncStream>>> {
+            Err(io::Error::new(self.error_kind, "connection refused"))
+        }
+    }
+
+    fn dummy_addr() -> SocketAddr {
+        "127.0.0.1:9999".parse().unwrap()
+    }
 
     #[tokio::test]
     async fn connect_to_open_port_returns_success() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        // Accept connections and respond in the background
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(async move {
-                    let mut buf = [0u8; 1024];
-                    let _ = stream.read(&mut buf).await;
-                    let _ = stream.shutdown().await;
-                });
-            }
-        });
+        let mock_stream = tokio_test::io::Builder::new()
+            .write(b"QUIT\n")
+            .read(b"goodbye")
+            .build();
 
         let check = NetworkConnectionCheck {
-            target_address: addr,
+            target_address: dummy_addr(),
             read_initial_response: false,
+            connector: Box::new(MockConnector::new(mock_stream)),
         };
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_none());
@@ -142,14 +169,12 @@ mod tests {
 
     #[tokio::test]
     async fn connect_to_closed_port_returns_failure() {
-        // Bind and immediately drop to get an unused port
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
-
         let check = NetworkConnectionCheck {
-            target_address: addr,
+            target_address: dummy_addr(),
             read_initial_response: false,
+            connector: Box::new(FailingConnector {
+                error_kind: io::ErrorKind::ConnectionRefused,
+            }),
         };
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_some());
@@ -161,26 +186,16 @@ mod tests {
 
     #[tokio::test]
     async fn read_initial_response_with_banner_returns_success() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    break;
-                };
-                tokio::spawn(async move {
-                    let _ = stream.write_all(b"220 Welcome\r\n").await;
-                    let mut buf = [0u8; 1024];
-                    let _ = stream.read(&mut buf).await;
-                    let _ = stream.shutdown().await;
-                });
-            }
-        });
+        let mock_stream = tokio_test::io::Builder::new()
+            .read(b"220 Welcome\r\n")
+            .write(b"QUIT\n")
+            .read(b"goodbye")
+            .build();
 
         let check = NetworkConnectionCheck {
-            target_address: addr,
+            target_address: dummy_addr(),
             read_initial_response: true,
+            connector: Box::new(MockConnector::new(mock_stream)),
         };
         let result = check.execute_check().await.unwrap();
         assert!(result.failure_reason.is_none());
@@ -192,6 +207,7 @@ mod tests {
         let check = NetworkConnectionCheck {
             target_address: addr,
             read_initial_response: false,
+            connector: Box::new(RealTcpConnector),
         };
         let name = check.check_name();
         assert!(name.contains("127.0.0.1:8080"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ pub(crate) mod checks;
 mod http_api_routes;
 pub(crate) mod options;
 pub(crate) mod status;
+pub(crate) mod util;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -70,101 +71,4 @@ async fn main() -> anyhow::Result<()> {
     };
 
     exit(exit_code)
-}
-
-#[cfg(test)]
-mod tests {
-    use axum::body::Body;
-    use axum::http::{Request, StatusCode};
-    use axum::routing::get;
-    use axum::{Extension, Router};
-    use tower::ServiceExt;
-
-    use crate::http_api_routes::get_status;
-    use crate::options::Options;
-    use crate::status::status_holder::FailingCheck;
-    use crate::status::status_manager::StatusManager;
-
-    fn test_options(mtc_path: Option<String>, force_success_path: Option<String>) -> Options {
-        Options {
-            bind_host: "127.0.0.1:0".to_string(),
-            revalidate_interval_seconds: 5,
-            force_success_file_path: force_success_path,
-            mtc_check_file_path: mtc_path,
-            socket_check_addr: None,
-            socket_check_read_initial_response: None,
-            http_check_url: None,
-            http_check_method: None,
-            http_check_response_codes: None,
-            http_proxy_protocol_version: None,
-        }
-    }
-
-    fn build_app(status_manager: &StatusManager) -> Router {
-        Router::new()
-            .route("/", get(get_status).options(get_status))
-            .layer(Extension(status_manager.status_holder()))
-    }
-
-    async fn do_request(app: Router) -> (StatusCode, Vec<FailingCheck>) {
-        let response = app
-            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
-            .await
-            .unwrap();
-        let status = response.status();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let checks: Vec<FailingCheck> = serde_json::from_slice(&body).unwrap();
-        (status, checks)
-    }
-
-    #[tokio::test]
-    async fn healthy_returns_200_empty_array() {
-        let options = test_options(
-            Some("/tmp/easycheck_test_nonexistent_mtc".to_string()),
-            Some("/tmp/easycheck_test_nonexistent_force".to_string()),
-        );
-        let manager = StatusManager::from_options(&options).unwrap();
-        manager.execute_status_checks().await;
-
-        let app = build_app(&manager);
-        let (status, checks) = do_request(app).await;
-        assert_eq!(status, StatusCode::OK);
-        assert!(checks.is_empty());
-    }
-
-    #[tokio::test]
-    async fn mtc_file_present_returns_503() {
-        let mtc_file = tempfile::NamedTempFile::new().unwrap();
-        let options = test_options(
-            Some(mtc_file.path().to_str().unwrap().to_string()),
-            Some("/tmp/easycheck_test_nonexistent_force".to_string()),
-        );
-        let manager = StatusManager::from_options(&options).unwrap();
-        manager.execute_status_checks().await;
-
-        let app = build_app(&manager);
-        let (status, checks) = do_request(app).await;
-        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-        assert!(!checks.is_empty());
-        assert!(checks.iter().any(|c| c.check_name == "mtc file"));
-    }
-
-    #[tokio::test]
-    async fn force_success_overrides_mtc_failure() {
-        let mtc_file = tempfile::NamedTempFile::new().unwrap();
-        let force_file = tempfile::NamedTempFile::new().unwrap();
-        let options = test_options(
-            Some(mtc_file.path().to_str().unwrap().to_string()),
-            Some(force_file.path().to_str().unwrap().to_string()),
-        );
-        let manager = StatusManager::from_options(&options).unwrap();
-        manager.execute_status_checks().await;
-
-        let app = build_app(&manager);
-        let (status, checks) = do_request(app).await;
-        assert_eq!(status, StatusCode::OK);
-        assert!(checks.is_empty());
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,7 @@ pub(crate) mod status;
 async fn main() -> anyhow::Result<()> {
     let options = Options::parse();
 
-    env_logger::Builder::new()
-        .filter_level(if options.debug {
-            log::LevelFilter::Debug
-        } else {
-            log::LevelFilter::Info
-        })
-        .init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
     let status_manager = match StatusManager::from_options(&options) {
         Ok(manager) => manager,
@@ -54,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(axum_status_holder));
     let listener = TcpListener::bind(&options.bind_host).await?;
     let axum_serve_future = axum::serve(listener, app).into_future();
-    log::info!(
+    eprintln!(
         "easycheck v{} listening on {}",
         env!("CARGO_PKG_VERSION"),
         &options.bind_host
@@ -103,7 +97,6 @@ mod tests {
             http_check_method: None,
             http_check_response_codes: None,
             http_proxy_protocol_version: None,
-            debug: false,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,19 @@ pub(crate) mod status;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let options = Options::parse();
+
+    env_logger::Builder::new()
+        .filter_level(if options.debug {
+            log::LevelFilter::Debug
+        } else {
+            log::LevelFilter::Info
+        })
+        .init();
+
     let status_manager = match StatusManager::from_options(&options) {
         Ok(manager) => manager,
         Err(error) => {
-            eprintln!(
+            log::error!(
                 "Unable to construct status manager based on provided options: {}",
                 error
             );
@@ -45,22 +54,124 @@ async fn main() -> anyhow::Result<()> {
         .layer(Extension(axum_status_holder));
     let listener = TcpListener::bind(&options.bind_host).await?;
     let axum_serve_future = axum::serve(listener, app).into_future();
-    println!("bound http listener to {}", &options.bind_host);
+    log::info!(
+        "easycheck v{} listening on {}",
+        env!("CARGO_PKG_VERSION"),
+        &options.bind_host
+    );
 
     let exit_code = tokio::select! {
         _ = status_updating_task => {
-            eprintln!("Status updater task failed");
+            log::error!("Status updater task failed");
             100
         }
         _ = axum_serve_future => {
-            eprintln!("Serving http endpoint failed");
+            log::error!("Serving http endpoint failed");
             101
         }
         _ = tokio::signal::ctrl_c() => {
-            println!("Quit signal received, exiting!");
+            log::info!("Quit signal received, exiting!");
             0
         }
     };
 
     exit(exit_code)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use axum::{Extension, Router};
+    use tower::ServiceExt;
+
+    use crate::http_api_routes::get_status;
+    use crate::options::Options;
+    use crate::status::status_holder::FailingCheck;
+    use crate::status::status_manager::StatusManager;
+
+    fn test_options(mtc_path: Option<String>, force_success_path: Option<String>) -> Options {
+        Options {
+            bind_host: "127.0.0.1:0".to_string(),
+            revalidate_interval_seconds: 5,
+            force_success_file_path: force_success_path,
+            mtc_check_file_path: mtc_path,
+            socket_check_addr: None,
+            socket_check_read_initial_response: None,
+            http_check_url: None,
+            http_check_method: None,
+            http_check_response_codes: None,
+            http_proxy_protocol_version: None,
+            debug: false,
+        }
+    }
+
+    fn build_app(status_manager: &StatusManager) -> Router {
+        Router::new()
+            .route("/", get(get_status).options(get_status))
+            .layer(Extension(status_manager.status_holder()))
+    }
+
+    async fn do_request(app: Router) -> (StatusCode, Vec<FailingCheck>) {
+        let response = app
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let checks: Vec<FailingCheck> = serde_json::from_slice(&body).unwrap();
+        (status, checks)
+    }
+
+    #[tokio::test]
+    async fn healthy_returns_200_empty_array() {
+        let options = test_options(
+            Some("/tmp/easycheck_test_nonexistent_mtc".to_string()),
+            Some("/tmp/easycheck_test_nonexistent_force".to_string()),
+        );
+        let manager = StatusManager::from_options(&options).unwrap();
+        manager.execute_status_checks().await;
+
+        let app = build_app(&manager);
+        let (status, checks) = do_request(app).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(checks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mtc_file_present_returns_503() {
+        let mtc_file = tempfile::NamedTempFile::new().unwrap();
+        let options = test_options(
+            Some(mtc_file.path().to_str().unwrap().to_string()),
+            Some("/tmp/easycheck_test_nonexistent_force".to_string()),
+        );
+        let manager = StatusManager::from_options(&options).unwrap();
+        manager.execute_status_checks().await;
+
+        let app = build_app(&manager);
+        let (status, checks) = do_request(app).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!checks.is_empty());
+        assert!(checks.iter().any(|c| c.check_name == "mtc file"));
+    }
+
+    #[tokio::test]
+    async fn force_success_overrides_mtc_failure() {
+        let mtc_file = tempfile::NamedTempFile::new().unwrap();
+        let force_file = tempfile::NamedTempFile::new().unwrap();
+        let options = test_options(
+            Some(mtc_file.path().to_str().unwrap().to_string()),
+            Some(force_file.path().to_str().unwrap().to_string()),
+        );
+        let manager = StatusManager::from_options(&options).unwrap();
+        manager.execute_status_checks().await;
+
+        let app = build_app(&manager);
+        let (status, checks) = do_request(app).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(checks.is_empty());
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -13,8 +13,6 @@ pub enum ProxyProtocolVersion {
 #[derive(Parser, Debug, Clone)]
 #[command(version)]
 pub(crate) struct Options {
-    #[arg(long = "debug", env = "EASYCHECK_DEBUG", default_value_t = false)]
-    pub debug: bool,
     #[arg(long = "bind", env = "EASYCHECK_BIND_HOST", required = true)]
     pub bind_host: String,
     #[arg(

--- a/src/options.rs
+++ b/src/options.rs
@@ -11,7 +11,10 @@ pub enum ProxyProtocolVersion {
 }
 
 #[derive(Parser, Debug, Clone)]
+#[command(version)]
 pub(crate) struct Options {
+    #[arg(long = "debug", env = "EASYCHECK_DEBUG", default_value_t = false)]
+    pub debug: bool,
     #[arg(long = "bind", env = "EASYCHECK_BIND_HOST", required = true)]
     pub bind_host: String,
     #[arg(

--- a/src/status/status_checker.rs
+++ b/src/status/status_checker.rs
@@ -2,17 +2,7 @@ use async_trait::async_trait;
 
 use crate::options::Options;
 
-/// The result of a status check.
-pub(crate) struct StatusCheckResult {
-    /// The reason why the status check failed. If present the check is
-    /// considered as failed, if absent the check was successful.
-    pub failure_reason: Option<String>,
-    /// Indicate if results from other status checkers should be ignored
-    /// and only this result should be returned.
-    pub ignore_other_results: bool,
-}
-
-/// Defines the shared behaviour how status checks are executed.
+/// Defines the shared behavior how status checks are executed.
 #[async_trait]
 pub trait StatusChecker: Send + Sync {
     /// Constructs a new instance of this checker based on the given options.
@@ -29,6 +19,16 @@ pub trait StatusChecker: Send + Sync {
     /// result is returned and bail_out is true, then the other checks
     /// will not be executed.
     async fn execute_check(&self) -> anyhow::Result<StatusCheckResult>;
+}
+
+/// The result of a status check.
+pub(crate) struct StatusCheckResult {
+    /// The reason why the status check failed. If present the check is
+    /// considered as failed, if absent the check was successful.
+    pub failure_reason: Option<String>,
+    /// Indicate if results from other status checkers should be ignored
+    /// and only this result should be returned.
+    pub ignore_other_results: bool,
 }
 
 impl StatusCheckResult {

--- a/src/status/status_checker.rs
+++ b/src/status/status_checker.rs
@@ -58,3 +58,33 @@ impl StatusCheckResult {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_success_has_no_failure_and_no_ignore() {
+        let result = StatusCheckResult::new_success();
+        assert!(result.failure_reason.is_none());
+        assert!(!result.ignore_other_results);
+    }
+
+    #[test]
+    fn new_failure_has_failure_reason_and_no_ignore() {
+        let result = StatusCheckResult::new_failure("something broke".to_string());
+        assert_eq!(result.failure_reason.as_deref(), Some("something broke"));
+        assert!(!result.ignore_other_results);
+    }
+
+    #[test]
+    fn ignore_other_results_sets_flag() {
+        let result = StatusCheckResult::new_success().ignore_other_results();
+        assert!(result.ignore_other_results);
+        assert!(result.failure_reason.is_none());
+
+        let result = StatusCheckResult::new_failure("fail".to_string()).ignore_other_results();
+        assert!(result.ignore_other_results);
+        assert_eq!(result.failure_reason.as_deref(), Some("fail"));
+    }
+}

--- a/src/status/status_holder.rs
+++ b/src/status/status_holder.rs
@@ -14,7 +14,7 @@ pub(crate) struct StatusHolder {
     current_status: Arc<RwLock<StatusCheckResults>>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, serde::Deserialize)]
 pub(crate) struct FailingCheck {
     /// The name of the check that failed.
     pub check_name: String,
@@ -80,5 +80,54 @@ impl StatusHolder {
     pub(super) async fn update_current_status(&self, check_results: StatusCheckResults) {
         let mut check_result_write_guard = self.current_status.write().await;
         *check_result_write_guard = check_results;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn initial_state_is_503_with_initial_check() {
+        let holder = StatusHolder::new_initial_failed();
+        let status = holder.current_status().await;
+        assert_eq!(status.api_response_code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status.failing_checks.len(), 1);
+        assert_eq!(status.failing_checks[0].check_name, "Initial Check");
+    }
+
+    #[tokio::test]
+    async fn update_to_healthy_returns_200_empty_failures() {
+        let holder = StatusHolder::new_initial_failed();
+        let healthy = StatusCheckResults {
+            timestamp: Instant::now(),
+            api_response_code: StatusCode::OK,
+            failing_checks: vec![],
+        };
+        holder.update_current_status(healthy).await;
+
+        let status = holder.current_status().await;
+        assert_eq!(status.api_response_code, StatusCode::OK);
+        assert!(status.failing_checks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_to_failing_returns_503_with_failure_info() {
+        let holder = StatusHolder::new_initial_failed();
+        let failing = StatusCheckResults {
+            timestamp: Instant::now(),
+            api_response_code: StatusCode::SERVICE_UNAVAILABLE,
+            failing_checks: vec![FailingCheck {
+                check_name: "test check".to_string(),
+                failure_reason: "it broke".to_string(),
+            }],
+        };
+        holder.update_current_status(failing).await;
+
+        let status = holder.current_status().await;
+        assert_eq!(status.api_response_code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status.failing_checks.len(), 1);
+        assert_eq!(status.failing_checks[0].check_name, "test check");
+        assert_eq!(status.failing_checks[0].failure_reason, "it broke");
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod tcp_connector;

--- a/src/util/tcp_connector.rs
+++ b/src/util/tcp_connector.rs
@@ -1,0 +1,26 @@
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+
+/// Combined trait for async read+write streams, needed because Rust does not
+/// allow multiple non-auto traits in a single `dyn` trait object.
+pub(crate) trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> AsyncStream for T {}
+
+#[async_trait]
+pub(crate) trait TcpConnector: Send + Sync {
+    async fn connect(&self, addr: &SocketAddr) -> std::io::Result<Pin<Box<dyn AsyncStream>>>;
+}
+
+pub(crate) struct RealTcpConnector;
+
+#[async_trait]
+impl TcpConnector for RealTcpConnector {
+    async fn connect(&self, addr: &SocketAddr) -> std::io::Result<Pin<Box<dyn AsyncStream>>> {
+        let stream = TcpStream::connect(addr).await?;
+        Ok(Box::pin(stream))
+    }
+}

--- a/src/util/tcp_connector.rs
+++ b/src/util/tcp_connector.rs
@@ -8,6 +8,7 @@ use tokio::net::TcpStream;
 /// Combined trait for async read+write streams, needed because Rust does not
 /// allow multiple non-auto traits in a single `dyn` trait object.
 pub(crate) trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send {}
+
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> AsyncStream for T {}
 
 #[async_trait]

--- a/tests/common/easycheck_process.rs
+++ b/tests/common/easycheck_process.rs
@@ -56,7 +56,7 @@ impl EasycheckProcess {
             if tokio::time::Instant::now() > deadline {
                 panic!("easycheck did not become ready within {:?}", POLL_TIMEOUT);
             }
-            if client.get(&self.base_url()).send().await.is_ok() {
+            if client.get(self.base_url()).send().await.is_ok() {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(50)).await;

--- a/tests/common/easycheck_process.rs
+++ b/tests/common/easycheck_process.rs
@@ -1,0 +1,107 @@
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+/// Revalidation interval passed to easycheck via --revalidation-interval.
+const REVALIDATION_INTERVAL_SECS: u64 = 1;
+
+/// The internal check timeout used by easycheck for individual checks (connect + I/O).
+const CHECK_TIMEOUT_SECS: u64 = 5;
+
+/// Timeout for poll-based helpers. Must account for the worst case:
+/// check timeout + revalidation interval + startup overhead.
+const POLL_TIMEOUT: Duration =
+    Duration::from_secs(CHECK_TIMEOUT_SECS + REVALIDATION_INTERVAL_SECS * 3);
+
+/// Duration to sleep when waiting for a subsequent check cycle (not the first one).
+pub const NEXT_CYCLE_WAIT: Duration = Duration::from_secs(REVALIDATION_INTERVAL_SECS * 2);
+
+pub struct EasycheckProcess {
+    child: Option<Child>,
+    pub port: u16,
+}
+
+impl EasycheckProcess {
+    /// Starts the easycheck binary with `--bind 127.0.0.1:<port> --revalidation-interval 1`
+    /// plus any extra arguments provided by the test.
+    pub fn start(extra_args: &[&str]) -> Self {
+        let port = allocate_port();
+        let bind = format!("127.0.0.1:{}", port);
+
+        let child = Command::new(env!("CARGO_BIN_EXE_easycheck"))
+            .arg("--bind")
+            .arg(&bind)
+            .arg("--revalidation-interval")
+            .arg(REVALIDATION_INTERVAL_SECS.to_string())
+            .args(extra_args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to start easycheck binary");
+
+        Self {
+            child: Some(child),
+            port,
+        }
+    }
+
+    pub fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    /// Polls GET / every 50ms until any HTTP response is received.
+    pub async fn wait_for_ready(&self) {
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + POLL_TIMEOUT;
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                panic!("easycheck did not become ready within {:?}", POLL_TIMEOUT);
+            }
+            if client.get(&self.base_url()).send().await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Polls GET / until the response body no longer contains "Initial Check",
+    /// indicating at least one real check cycle has completed.
+    pub async fn wait_for_check_cycle(&self) {
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + POLL_TIMEOUT;
+        loop {
+            if tokio::time::Instant::now() > deadline {
+                panic!(
+                    "first check cycle did not complete within {:?}",
+                    POLL_TIMEOUT
+                );
+            }
+            if let Ok(resp) = client.get(self.base_url()).send().await {
+                if let Ok(body) = resp.text().await {
+                    if !body.contains("Initial Check") {
+                        return;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+}
+
+impl Drop for EasycheckProcess {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Allocates a free OS port by binding to port 0 and returning the assigned port.
+/// The listener is dropped immediately, freeing the port for use.
+pub fn allocate_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}

--- a/tests/common/mock_http_server.rs
+++ b/tests/common/mock_http_server.rs
@@ -1,0 +1,56 @@
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum::{Extension, Router};
+
+pub struct MockHttpServer {
+    pub port: u16,
+    status_code: Arc<AtomicU16>,
+    _shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+async fn handler(Extension(status_code): Extension<Arc<AtomicU16>>) -> StatusCode {
+    let code = status_code.load(Ordering::Relaxed);
+    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+impl MockHttpServer {
+    /// Starts a mock HTTP server on a random port that responds with the given status code.
+    pub async fn start(status: u16) -> Self {
+        let status_code = Arc::new(AtomicU16::new(status));
+
+        let app = Router::new()
+            .fallback(handler)
+            .layer(Extension(status_code.clone()));
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        Self {
+            port,
+            status_code,
+            _shutdown_tx: tx,
+        }
+    }
+
+    /// Dynamically changes the status code returned by the mock.
+    pub fn set_status(&self, status: u16) {
+        self.status_code.store(status, Ordering::Relaxed);
+    }
+
+    /// Returns the base URL of the mock server.
+    pub fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/", self.port)
+    }
+}

--- a/tests/common/mock_proxy_http_server.rs
+++ b/tests/common/mock_proxy_http_server.rs
@@ -1,0 +1,105 @@
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::server::conn::http1::Builder;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
+
+#[derive(Copy, Clone)]
+enum ProxyVersion {
+    V1,
+    V2,
+}
+
+pub struct MockProxyProtocolHttpServer {
+    pub port: u16,
+    _shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl MockProxyProtocolHttpServer {
+    pub async fn start_v1(status: u16) -> Self {
+        Self::start(status, ProxyVersion::V1).await
+    }
+
+    pub async fn start_v2(status: u16) -> Self {
+        Self::start(status, ProxyVersion::V2).await
+    }
+
+    async fn start(status: u16, version: ProxyVersion) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = async {
+                    loop {
+                        if let Ok((mut stream, _)) = listener.accept().await {
+                            tokio::spawn(async move {
+                                match version {
+                                    ProxyVersion::V1 => read_proxy_v1(&mut stream).await,
+                                    ProxyVersion::V2 => read_proxy_v2(&mut stream).await,
+                                }
+                                serve_http(stream, status).await;
+                            });
+                        }
+                    }
+                } => {}
+                _ = rx => {}
+            }
+        });
+
+        Self {
+            port,
+            _shutdown_tx: tx,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("http://127.0.0.1:{}/", self.port)
+    }
+}
+
+/// Reads a PROXY protocol v1 header (a single text line ending in \r\n).
+async fn read_proxy_v1(stream: &mut TcpStream) {
+    let mut buf = Vec::new();
+    loop {
+        let byte = stream.read_u8().await.unwrap();
+        buf.push(byte);
+        if buf.ends_with(b"\r\n") {
+            break;
+        }
+    }
+}
+
+/// Reads a PROXY protocol v2 header (16-byte fixed header + variable payload).
+async fn read_proxy_v2(stream: &mut TcpStream) {
+    // 12 bytes signature + version/command + family/protocol + 2 bytes length
+    let mut header = [0u8; 16];
+    stream.read_exact(&mut header).await.unwrap();
+    let remaining_len = u16::from_be_bytes([header[14], header[15]]) as usize;
+    if remaining_len > 0 {
+        let mut remaining = vec![0u8; remaining_len];
+        stream.read_exact(&mut remaining).await.unwrap();
+    }
+}
+
+/// Serves a single HTTP/1.1 request on the stream using hyper, returning the given status code.
+async fn serve_http(stream: TcpStream, status: u16) {
+    let status_code = hyper::StatusCode::from_u16(status).unwrap();
+    let service = service_fn(
+        move |_req: hyper::Request<hyper::body::Incoming>| async move {
+            Ok::<_, hyper::Error>(
+                hyper::Response::builder()
+                    .status(status_code)
+                    .body(Full::new(Bytes::from("ok")))
+                    .unwrap(),
+            )
+        },
+    );
+
+    let _ = Builder::new()
+        .serve_connection(TokioIo::new(stream), service)
+        .await;
+}

--- a/tests/common/mock_tcp_server.rs
+++ b/tests/common/mock_tcp_server.rs
@@ -1,0 +1,50 @@
+pub struct MockTcpServer {
+    pub port: u16,
+    _shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl MockTcpServer {
+    /// Starts a mock TCP server that accepts connections,
+    /// reads incoming data (e.g. the QUIT message), and responds with "OK\n".
+    pub async fn start() -> Self {
+        Self::start_inner(None).await
+    }
+
+    /// Starts a mock TCP server that sends a banner before reading/responding.
+    pub async fn start_with_banner(banner: &str) -> Self {
+        Self::start_inner(Some(banner.to_string())).await
+    }
+
+    async fn start_inner(banner: Option<String>) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = async {
+                    loop {
+                        if let Ok((mut stream, _)) = listener.accept().await {
+                            let banner = banner.clone();
+                            tokio::spawn(async move {
+                                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                                if let Some(banner) = banner {
+                                    let _ = stream.write_all(banner.as_bytes()).await;
+                                }
+                                let mut buf = [0u8; 1024];
+                                let _ = stream.read(&mut buf).await;
+                                let _ = stream.write_all(b"OK\n").await;
+                            });
+                        }
+                    }
+                } => {}
+                _ = rx => {}
+            }
+        });
+
+        Self {
+            port,
+            _shutdown_tx: tx,
+        }
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,4 @@
+pub mod easycheck_process;
+pub mod mock_http_server;
+pub mod mock_proxy_http_server;
+pub mod mock_tcp_server;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,8 +5,6 @@ use common::mock_http_server::MockHttpServer;
 use common::mock_proxy_http_server::MockProxyProtocolHttpServer;
 use common::mock_tcp_server::MockTcpServer;
 
-// ---- Group 1: Startup ----
-
 /// Before the first check cycle completes, easycheck returns 503 with "Initial Check".
 #[tokio::test]
 async fn initial_state_returns_503() {
@@ -47,8 +45,6 @@ async fn healthy_after_first_check_cycle() {
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body, serde_json::json!([]));
 }
-
-// ---- Group 2: File Checks ----
 
 /// When the maintenance file exists, easycheck returns 503.
 #[tokio::test]
@@ -113,8 +109,6 @@ async fn force_success_overrides_all_failures() {
     let resp = reqwest::get(&proc.base_url()).await.unwrap();
     assert_eq!(resp.status().as_u16(), 200);
 }
-
-// ---- Group 3: HTTP Check ----
 
 /// HTTP check passes when backend returns 200.
 #[tokio::test]
@@ -218,8 +212,6 @@ async fn http_check_with_proxy_protocol_v2() {
     assert_eq!(resp.status().as_u16(), 200);
 }
 
-// ---- Group 4: TCP/Socket Check ----
-
 /// Socket check passes when TCP server is reachable and responds.
 #[tokio::test]
 async fn socket_check_healthy() {
@@ -277,8 +269,6 @@ async fn socket_check_connection_refused() {
     let body = resp.text().await.unwrap();
     assert!(body.contains("network connection check"));
 }
-
-// ---- Group 5: Combined ----
 
 /// Multiple checks (HTTP + socket) all pass -> 200.
 #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,94 @@
+// TODO convert them to real integration tests
+// #[cfg(test)]
+// mod tests {
+//     use axum::body::Body;
+//     use axum::http::{Request, StatusCode};
+//     use tower::ServiceExt;
+//
+//     use crate::status::status_holder::FailingCheck;
+//
+//     use super::*;
+//
+//     fn test_options(mtc_path: Option<String>, force_success_path: Option<String>) -> Options {
+//         Options {
+//             bind_host: "127.0.0.1:0".to_string(),
+//             revalidate_interval_seconds: 5,
+//             force_success_file_path: force_success_path,
+//             mtc_check_file_path: mtc_path,
+//             socket_check_addr: None,
+//             socket_check_read_initial_response: None,
+//             http_check_url: None,
+//             http_check_method: None,
+//             http_check_response_codes: None,
+//             http_proxy_protocol_version: None,
+//         }
+//     }
+//
+//     fn build_app(status_manager: &StatusManager) -> Router {
+//         Router::new()
+//             .route("/", get(get_status).options(get_status))
+//             .layer(Extension(status_manager.status_holder()))
+//     }
+//
+//     async fn do_request(app: Router) -> (StatusCode, Vec<FailingCheck>) {
+//         let response = app
+//             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+//             .await
+//             .unwrap();
+//         let status = response.status();
+//         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+//             .await
+//             .unwrap();
+//         let checks: Vec<FailingCheck> = serde_json::from_slice(&body).unwrap();
+//         (status, checks)
+//     }
+//
+//     #[tokio::test]
+//     async fn healthy_returns_200_empty_array() {
+//         let options = test_options(
+//             Some("/tmp/easycheck_test_nonexistent_mtc".to_string()),
+//             Some("/tmp/easycheck_test_nonexistent_force".to_string()),
+//         );
+//         let manager = StatusManager::from_options(&options).unwrap();
+//         manager.execute_status_checks().await;
+//
+//         let app = build_app(&manager);
+//         let (status, checks) = do_request(app).await;
+//         assert_eq!(status, StatusCode::OK);
+//         assert!(checks.is_empty());
+//     }
+//
+//     #[tokio::test]
+//     async fn mtc_file_present_returns_503() {
+//         let mtc_file = tempfile::NamedTempFile::new().unwrap();
+//         let options = test_options(
+//             Some(mtc_file.path().to_str().unwrap().to_string()),
+//             Some("/tmp/easycheck_test_nonexistent_force".to_string()),
+//         );
+//         let manager = StatusManager::from_options(&options).unwrap();
+//         manager.execute_status_checks().await;
+//
+//         let app = build_app(&manager);
+//         let (status, checks) = do_request(app).await;
+//         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+//         assert!(!checks.is_empty());
+//         assert!(checks.iter().any(|c| c.check_name == "mtc file"));
+//     }
+//
+//     #[tokio::test]
+//     async fn force_success_overrides_mtc_failure() {
+//         let mtc_file = tempfile::NamedTempFile::new().unwrap();
+//         let force_file = tempfile::NamedTempFile::new().unwrap();
+//         let options = test_options(
+//             Some(mtc_file.path().to_str().unwrap().to_string()),
+//             Some(force_file.path().to_str().unwrap().to_string()),
+//         );
+//         let manager = StatusManager::from_options(&options).unwrap();
+//         manager.execute_status_checks().await;
+//
+//         let app = build_app(&manager);
+//         let (status, checks) = do_request(app).await;
+//         assert_eq!(status, StatusCode::OK);
+//         assert!(checks.is_empty());
+//     }
+// }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,94 +1,322 @@
-// TODO convert them to real integration tests
-// #[cfg(test)]
-// mod tests {
-//     use axum::body::Body;
-//     use axum::http::{Request, StatusCode};
-//     use tower::ServiceExt;
-//
-//     use crate::status::status_holder::FailingCheck;
-//
-//     use super::*;
-//
-//     fn test_options(mtc_path: Option<String>, force_success_path: Option<String>) -> Options {
-//         Options {
-//             bind_host: "127.0.0.1:0".to_string(),
-//             revalidate_interval_seconds: 5,
-//             force_success_file_path: force_success_path,
-//             mtc_check_file_path: mtc_path,
-//             socket_check_addr: None,
-//             socket_check_read_initial_response: None,
-//             http_check_url: None,
-//             http_check_method: None,
-//             http_check_response_codes: None,
-//             http_proxy_protocol_version: None,
-//         }
-//     }
-//
-//     fn build_app(status_manager: &StatusManager) -> Router {
-//         Router::new()
-//             .route("/", get(get_status).options(get_status))
-//             .layer(Extension(status_manager.status_holder()))
-//     }
-//
-//     async fn do_request(app: Router) -> (StatusCode, Vec<FailingCheck>) {
-//         let response = app
-//             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
-//             .await
-//             .unwrap();
-//         let status = response.status();
-//         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-//             .await
-//             .unwrap();
-//         let checks: Vec<FailingCheck> = serde_json::from_slice(&body).unwrap();
-//         (status, checks)
-//     }
-//
-//     #[tokio::test]
-//     async fn healthy_returns_200_empty_array() {
-//         let options = test_options(
-//             Some("/tmp/easycheck_test_nonexistent_mtc".to_string()),
-//             Some("/tmp/easycheck_test_nonexistent_force".to_string()),
-//         );
-//         let manager = StatusManager::from_options(&options).unwrap();
-//         manager.execute_status_checks().await;
-//
-//         let app = build_app(&manager);
-//         let (status, checks) = do_request(app).await;
-//         assert_eq!(status, StatusCode::OK);
-//         assert!(checks.is_empty());
-//     }
-//
-//     #[tokio::test]
-//     async fn mtc_file_present_returns_503() {
-//         let mtc_file = tempfile::NamedTempFile::new().unwrap();
-//         let options = test_options(
-//             Some(mtc_file.path().to_str().unwrap().to_string()),
-//             Some("/tmp/easycheck_test_nonexistent_force".to_string()),
-//         );
-//         let manager = StatusManager::from_options(&options).unwrap();
-//         manager.execute_status_checks().await;
-//
-//         let app = build_app(&manager);
-//         let (status, checks) = do_request(app).await;
-//         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
-//         assert!(!checks.is_empty());
-//         assert!(checks.iter().any(|c| c.check_name == "mtc file"));
-//     }
-//
-//     #[tokio::test]
-//     async fn force_success_overrides_mtc_failure() {
-//         let mtc_file = tempfile::NamedTempFile::new().unwrap();
-//         let force_file = tempfile::NamedTempFile::new().unwrap();
-//         let options = test_options(
-//             Some(mtc_file.path().to_str().unwrap().to_string()),
-//             Some(force_file.path().to_str().unwrap().to_string()),
-//         );
-//         let manager = StatusManager::from_options(&options).unwrap();
-//         manager.execute_status_checks().await;
-//
-//         let app = build_app(&manager);
-//         let (status, checks) = do_request(app).await;
-//         assert_eq!(status, StatusCode::OK);
-//         assert!(checks.is_empty());
-//     }
-// }
+mod common;
+
+use common::easycheck_process::{allocate_port, EasycheckProcess, NEXT_CYCLE_WAIT};
+use common::mock_http_server::MockHttpServer;
+use common::mock_proxy_http_server::MockProxyProtocolHttpServer;
+use common::mock_tcp_server::MockTcpServer;
+
+// ---- Group 1: Startup ----
+
+/// Before the first check cycle completes, easycheck returns 503 with "Initial Check".
+#[tokio::test]
+async fn initial_state_returns_503() {
+    // Start a TCP listener that accepts connections but never responds,
+    // keeping the HTTP check pending indefinitely (until its 5s timeout).
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let hanging_port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        loop {
+            if let Ok((stream, _)) = listener.accept().await {
+                // Keep the connection alive but never respond
+                tokio::spawn(async move {
+                    let _keep_alive = stream;
+                    tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                });
+            }
+        }
+    });
+
+    let url = format!("http://127.0.0.1:{}/", hanging_port);
+    let proc = EasycheckProcess::start(&["--http-url", &url]);
+    proc.wait_for_ready().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("Initial Check"));
+}
+
+/// With no failing checks configured, easycheck becomes healthy after the first cycle.
+#[tokio::test]
+async fn healthy_after_first_check_cycle() {
+    let proc = EasycheckProcess::start(&[]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body, serde_json::json!([]));
+}
+
+// ---- Group 2: File Checks ----
+
+/// When the maintenance file exists, easycheck returns 503.
+#[tokio::test]
+async fn mtc_file_present_returns_503() {
+    let mtc_file = tempfile::NamedTempFile::new().unwrap();
+    let mtc_path = mtc_file.path().to_str().unwrap().to_string();
+
+    let proc = EasycheckProcess::start(&["--mtc-file-path", &mtc_path]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("mtc file"));
+}
+
+/// When the maintenance file does not exist, easycheck returns 200.
+#[tokio::test]
+async fn mtc_file_absent_returns_200() {
+    let proc = EasycheckProcess::start(&[
+        "--mtc-file-path",
+        "/tmp/easycheck_test_nonexistent_mtc_file",
+    ]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Force success file overrides a failing maintenance check.
+#[tokio::test]
+async fn force_success_overrides_mtc() {
+    let mtc_file = tempfile::NamedTempFile::new().unwrap();
+    let force_file = tempfile::NamedTempFile::new().unwrap();
+    let mtc_path = mtc_file.path().to_str().unwrap().to_string();
+    let force_path = force_file.path().to_str().unwrap().to_string();
+
+    let proc = EasycheckProcess::start(&[
+        "--mtc-file-path",
+        &mtc_path,
+        "--force-success-file-path",
+        &force_path,
+    ]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Force success file overrides all failures including HTTP check failures.
+#[tokio::test]
+async fn force_success_overrides_all_failures() {
+    let force_file = tempfile::NamedTempFile::new().unwrap();
+    let force_path = force_file.path().to_str().unwrap().to_string();
+    let mock = MockHttpServer::start(500).await;
+    let url = mock.url();
+
+    let proc =
+        EasycheckProcess::start(&["--force-success-file-path", &force_path, "--http-url", &url]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+// ---- Group 3: HTTP Check ----
+
+/// HTTP check passes when backend returns 200.
+#[tokio::test]
+async fn http_check_healthy_backend() {
+    let mock = MockHttpServer::start(200).await;
+    let url = mock.url();
+
+    let proc = EasycheckProcess::start(&["--http-url", &url]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// HTTP check fails when backend returns 500.
+#[tokio::test]
+async fn http_check_unhealthy_backend() {
+    let mock = MockHttpServer::start(500).await;
+    let url = mock.url();
+
+    let proc = EasycheckProcess::start(&["--http-url", &url]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("http endpoint check"));
+}
+
+/// HTTP check accepts custom status codes (e.g. 204).
+#[tokio::test]
+async fn http_check_custom_status_codes() {
+    let mock = MockHttpServer::start(204).await;
+    let url = mock.url();
+
+    let proc = EasycheckProcess::start(&["--http-url", &url, "--http-status-codes", "204"]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// HTTP check fails when backend is completely down (connection refused).
+#[tokio::test]
+async fn http_check_backend_down() {
+    let dead_port = allocate_port();
+    let url = format!("http://127.0.0.1:{}/", dead_port);
+
+    let proc = EasycheckProcess::start(&["--http-url", &url]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+}
+
+/// Easycheck follows backend state transitions (200 -> 500).
+#[tokio::test]
+async fn http_check_state_transition() {
+    let mock = MockHttpServer::start(200).await;
+    let url = mock.url();
+
+    let proc = EasycheckProcess::start(&["--http-url", &url]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+
+    mock.set_status(500);
+    // Wait for easycheck to pick up the change in a subsequent check cycle
+    tokio::time::sleep(NEXT_CYCLE_WAIT).await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+}
+
+/// HTTP check passes through a PROXY PROTOCOL v1 server.
+#[tokio::test]
+async fn http_check_with_proxy_protocol_v1() {
+    let mock = MockProxyProtocolHttpServer::start_v1(200).await;
+    let url = mock.url();
+
+    let proc =
+        EasycheckProcess::start(&["--http-url", &url, "--http-proxy-protocol-version", "v1"]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// HTTP check passes through a PROXY PROTOCOL v2 server.
+#[tokio::test]
+async fn http_check_with_proxy_protocol_v2() {
+    let mock = MockProxyProtocolHttpServer::start_v2(200).await;
+    let url = mock.url();
+
+    let proc =
+        EasycheckProcess::start(&["--http-url", &url, "--http-proxy-protocol-version", "v2"]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+// ---- Group 4: TCP/Socket Check ----
+
+/// Socket check passes when TCP server is reachable and responds.
+#[tokio::test]
+async fn socket_check_healthy() {
+    let mock_tcp = MockTcpServer::start().await;
+    let addr = format!("127.0.0.1:{}", mock_tcp.port);
+
+    let proc = EasycheckProcess::start(&["--socket-addr", &addr]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Socket check passes when server sends an initial banner and --read-initial-response is set.
+#[tokio::test]
+async fn socket_check_with_initial_banner() {
+    let mock_tcp = MockTcpServer::start_with_banner("220 Welcome\r\n").await;
+    let addr = format!("127.0.0.1:{}", mock_tcp.port);
+
+    let proc =
+        EasycheckProcess::start(&["--socket-addr", &addr, "--read-initial-response", "true"]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// Socket check times out when --read-initial-response is set but server never sends a banner.
+#[tokio::test]
+async fn socket_check_no_banner_with_read_initial_response() {
+    let mock_tcp = MockTcpServer::start().await;
+    let addr = format!("127.0.0.1:{}", mock_tcp.port);
+
+    let proc =
+        EasycheckProcess::start(&["--socket-addr", &addr, "--read-initial-response", "true"]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("network connection check"));
+}
+
+/// Socket check fails when no TCP server is running (connection refused).
+#[tokio::test]
+async fn socket_check_connection_refused() {
+    let dead_port = allocate_port();
+    let addr = format!("127.0.0.1:{}", dead_port);
+
+    let proc = EasycheckProcess::start(&["--socket-addr", &addr]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("network connection check"));
+}
+
+// ---- Group 5: Combined ----
+
+/// Multiple checks (HTTP + socket) all pass -> 200.
+#[tokio::test]
+async fn multiple_checks_all_pass() {
+    let mock_http = MockHttpServer::start(200).await;
+    let mock_tcp = MockTcpServer::start().await;
+    let http_url = mock_http.url();
+    let tcp_addr = format!("127.0.0.1:{}", mock_tcp.port);
+
+    let proc = EasycheckProcess::start(&["--http-url", &http_url, "--socket-addr", &tcp_addr]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+/// When one of multiple checks fails, easycheck returns 503 with only the failing check.
+#[tokio::test]
+async fn multiple_checks_one_fails() {
+    let mock_http = MockHttpServer::start(200).await;
+    let http_url = mock_http.url();
+    let dead_port = allocate_port();
+    let tcp_addr = format!("127.0.0.1:{}", dead_port);
+
+    let proc = EasycheckProcess::start(&["--http-url", &http_url, "--socket-addr", &tcp_addr]);
+    proc.wait_for_check_cycle().await;
+
+    let resp = reqwest::get(&proc.base_url()).await.unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("network connection check"),
+        "expected socket failure in body: {}",
+        body
+    );
+    assert!(
+        !body.contains("http endpoint check"),
+        "http check should not fail: {}",
+        body
+    );
+}


### PR DESCRIPTION
https://easybill.atlassian.net/browse/PLAT-291

Changes:
- added tests
  - unit tests
    - mtc and force_success checks: using tmp files
    - tcp connection checks: using a connector trait, which can be mocked with deterministic streams
    - http checks: using a connector trait, which can be mocked with deterministic duplex streams 
  - integration tests: by running the binary
    - mtc and force success
    - http server
    - tcp endpoint
- added CI test run
- uses Cargo.toml as source for version number
- added debug logging output

Disclaimer:
- these changes were created by using Claude Code
- I reviewed all lines of code by myself with an explanation of Claude Code